### PR TITLE
Added retry logic, error logging for image downloads, and validation checks for PDF creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+Downloads/
+
+*.txt

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -12,7 +12,11 @@ URLS_FILE = "URLs.txt"         # The name of the file containing the list of
 MAX_WORKERS = 5         # Maximum number of concurrent workers.
 TASK_COLOR = "cyan"     # Color used for task-related output in the terminal.
 CHUNK_SIZE = 16 * 1024  # Size of data chunks (bytes) to be processed at a time.
-TIMEOUT = 10            # Timeout value (in seconds) for HTTP requests.
+TIMEOUT = 20            # Timeout value (in seconds) for HTTP requests.
+MAX_RETRIES = 30         # Maximum number of retries for failed HTTP requests.
+SECONDS = 10            # Number of seconds to wait between retries.
+MAX_RETRIES_PAGE = 5    # Maximum number of retries for failed page requests.
+SECONDS_PAGE = 5        # Number of seconds to wait between page retries.
 
 # Headers used for general HTTP requests, mimicking a browser user agent.
 HEADERS = {

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -15,8 +15,6 @@ CHUNK_SIZE = 16 * 1024  # Size of data chunks (bytes) to be processed at a time.
 TIMEOUT = 20            # Timeout value (in seconds) for HTTP requests.
 MAX_RETRIES = 30         # Maximum number of retries for failed HTTP requests.
 SECONDS = 10            # Number of seconds to wait between retries.
-MAX_RETRIES_PAGE = 5    # Maximum number of retries for failed page requests.
-SECONDS_PAGE = 5        # Number of seconds to wait between page retries.
 
 # Headers used for general HTTP requests, mimicking a browser user agent.
 HEADERS = {

--- a/helpers/general_utils.py
+++ b/helpers/general_utils.py
@@ -34,19 +34,19 @@ async def check_real_page(initial_response, session, timeout=10):
                        BeautifulSoup object, if the real page was successfully
                        fetched, otherwise the original response.
     """
-    if "document.cookie" in initial_response.body.script.text:
-        # print("Found not final page, trying to fetch real one again...")
-
+    parsed_response = initial_response
+    if initial_response.body and initial_response.body.script and "document.cookie" in initial_response.body.script.text:
+        print("Found not final page, trying to fetch real one again...")
         # Extract the cookie
         cookie_regex = r'document\.cookie="([^;]+)'
         match = re.search(cookie_regex, initial_response.body.script.text)
 
         if match:
             cookie = match.group(1)
-            # print("Extracted Cookie:", cookie)
+            print("Extracted Cookie:", cookie)
             cookie = cookie.strip().split("=")
         else:
-            # print("No cookie found")
+            print("No cookie found")
             return initial_response
 
         # Extract the link
@@ -55,7 +55,7 @@ async def check_real_page(initial_response, session, timeout=10):
 
         if match:
             link = match.group(1)  # Extracted link
-            # print("Extracted Link:", link)
+            print("Extracted Link:", link)
         else:
             print("No link found")
             return initial_response

--- a/helpers/general_utils.py
+++ b/helpers/general_utils.py
@@ -43,10 +43,10 @@ async def check_real_page(initial_response, session, timeout=10):
 
         if match:
             cookie = match.group(1)
-            print("Extracted Cookie:", cookie)
+            #print("Extracted Cookie:", cookie)
             cookie = cookie.strip().split("=")
         else:
-            print("No cookie found")
+            #print("No cookie found")
             return initial_response
 
         # Extract the link
@@ -55,7 +55,7 @@ async def check_real_page(initial_response, session, timeout=10):
 
         if match:
             link = match.group(1)  # Extracted link
-            print("Extracted Link:", link)
+            #print("Extracted Link:", link)
         else:
             print("No link found")
             return initial_response

--- a/helpers/pdf_generator.py
+++ b/helpers/pdf_generator.py
@@ -49,16 +49,23 @@ def convert2pdf(main_path, output_path, pdf_name):
         key=lambda filename: int(''.join(filter(str.isdigit, filename)))
     )
 
+    if not filenames:
+        print(f"No images found in {main_path}.")
+        return
+
     path_to_pdf = os.path.join(os.getcwd(), output_path, f"{pdf_name}.pdf")
     pics = [
         Image.open(os.path.join(main_path, filename))
         for filename in filenames
     ]
 
-    pics[0].save(
-        path_to_pdf, "PDF", resolution=100.0, save_all=True,
-        append_images=pics[1:]
-    )
+    if pics:
+        pics[0].save(
+            path_to_pdf, "PDF", resolution=100.0, save_all=True,
+            append_images=pics[1:]
+        )
+    else:
+        print(f"No valid images to convert in {main_path}.")
 
 def get_num_folders(current_directory):
     """

--- a/manga_downloader.py
+++ b/manga_downloader.py
@@ -18,7 +18,6 @@ import os
 import argparse
 import asyncio
 import random
-import time
 
 import aiohttp
 import requests
@@ -224,7 +223,7 @@ async def extract_download_links(chapter_urls):
         # Remove the "1.png" suffix from each download link
         download_links = [
             download_link[:-len("1.png")]
-            for download_link in results #if download_link
+            for download_link in results if download_link
         ]
 
     return download_links

--- a/manga_downloader.py
+++ b/manga_downloader.py
@@ -17,6 +17,8 @@ Example:
 import os
 import argparse
 import asyncio
+import random
+import time
 
 import aiohttp
 import requests
@@ -41,15 +43,18 @@ from helpers.config import (
     DOWNLOAD_FOLDER,
     CHUNK_SIZE,
     TIMEOUT,
-    HEADERS
+    HEADERS,
+    MAX_RETRIES,
+    SECONDS
 )
 
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 SESSION = requests.Session()
 
+
 async def fetch_chapter_data(chapter_url, session):
     """
-    Fetches the number of pages for a given chapter URL.
+    Fetches the number of pages for a given chapter URL, retrying if necessary.
 
     Args:
         chapter_url (str): The URL of the chapter to fetch data from.
@@ -58,31 +63,33 @@ async def fetch_chapter_data(chapter_url, session):
 
     Returns:
         tuple: A tuple containing the chapter URL and the number of
-               pages (str), or (None, None) if an error occurs.
-
-    Raises:
-        aiohttp.ClientError: If there are network-related issues during the
-                             HTTP request.
-        asyncio.TimeoutError: If the HTTP request times out.
+               pages (str), or (None, None) if all attempts fail.
     """
-    try:
-        async with session.get(chapter_url, timeout=TIMEOUT) as response:
-            soup = BeautifulSoup(await response.text(), 'html.parser')
-            soup = await check_real_page(soup, session, TIMEOUT)
+    attempt = 0
+    while attempt < MAX_RETRIES:
+        try:
+            async with session.get(chapter_url, timeout=TIMEOUT) as response:
+                soup = BeautifulSoup(await response.text(), 'html.parser')
+                soup = await check_real_page(soup, session, TIMEOUT)
 
+                page_item = soup.find('select', {'class': 'page custom-select'})
+                if page_item:
+                    option_text = page_item.find('option').get_text()
+                    num_pages = option_text.split('/')[-1]
+                    return chapter_url, num_pages  # Page count found
 
-            page_item = soup.find('select', {'class': 'page custom-select'})
-            if page_item:
-                option_text = page_item.find('option').get_text()
-                num_pages = option_text.split('/')[-1]
-                return chapter_url, num_pages
+                print(f"[Retry {attempt+1}/{MAX_RETRIES}] Page count not found for {chapter_url}")
+        
+        except (aiohttp.ClientError, asyncio.TimeoutError) as err:
+            print(f"[Retry {attempt+1}/{MAX_RETRIES}] Network error fetching {chapter_url}: {err}")
 
-            return None, None
+        attempt += 1
+        if attempt < MAX_RETRIES:
+            await asyncio.sleep(1 + random.uniform(0, SECONDS-1))  # Random wait between 1 and SECOND seconds
 
-    except (aiohttp.ClientError, asyncio.TimeoutError) as err:
-        print(f"Network error while fetching {chapter_url}: {err}")
-
+    print(f"Failed to fetch chapter data for {chapter_url} after {MAX_RETRIES} attempts.")
     return None, None
+
 
 async def get_chapter_urls_and_pages(soup, session, match="/read/"):
     """
@@ -145,43 +152,46 @@ async def extract_chapters_info(soup):
             - List of corresponding page counts (str).
     """
     async with aiohttp.ClientSession() as session:
-        return await get_chapter_urls_and_pages(soup, session)
+        chapter_urls, pages_per_chapter = await get_chapter_urls_and_pages(soup, session)
+        return chapter_urls, pages_per_chapter
+
+
 
 async def fetch_download_link(chapter_url, session):
     """
-    Fetches the download link for the first image in a chapter page.
+    Fetches the download link for the first image in a chapter page,
+    retrying multiple times if necessary.
 
     Args:
-        chapter_url (str): The URL of the chapter to fetch the download link
-                           from.
+        chapter_url (str): The URL of the chapter to fetch the download link from.
         session (aiohttp.ClientSession): The aiohttp session used for making
                                          the HTTP request.
 
     Returns:
-        str or None: The download URL for the image if found, or None if not
-                     found or an error occurs.
-
-    Raises:
-        asyncio.TimeoutError: If the HTTP request times out.
-        aiohttp.ClientError: If a network-related error occurs during the
-                             request.
+        str or None: The download URL for the image if found, or None if all attempts fail.
     """
-    try:
-        url_to_fetch = f"{chapter_url}/1"
-        async with session.get(url_to_fetch, timeout=TIMEOUT) as response:
-            soup = BeautifulSoup(await response.text(), 'html.parser')
-            validated_soup = await check_real_page(soup, session, TIMEOUT)
+    attempt = 0
+    while attempt < MAX_RETRIES:
+        try:
+            url_to_fetch = f"{chapter_url}/1"
+            async with session.get(url_to_fetch, timeout=TIMEOUT) as response:
+                soup = BeautifulSoup(await response.text(), 'html.parser')
+                validated_soup = await check_real_page(soup, session, TIMEOUT)
 
-            img_items = validated_soup.find_all('img', {'class': 'img-fluid'})
-            if img_items:
-                download_link = img_items[-1]['src']
-                return download_link
+                img_items = validated_soup.find_all('img', {'class': 'img-fluid'})
+                if img_items:
+                    return img_items[-1]['src']  # Download link found
 
-            return None
+                print(f"[Retry {attempt+1}/{MAX_RETRIES}] Download link not found for {chapter_url}")
+        
+        except (aiohttp.ClientError, asyncio.TimeoutError) as err:
+            print(f"[Retry {attempt+1}/{MAX_RETRIES}] Network error fetching {chapter_url}: {err}")
 
-    except (aiohttp.ClientError, asyncio.TimeoutError) as err:
-        print(f"Network error while fetching {chapter_url}: {err}")
-
+        attempt += 1
+        if attempt < MAX_RETRIES:
+            await asyncio.sleep(1 + random.uniform(0, SECONDS))  # Random wait between 1 and 5 seconds
+    
+    print(f"Failed to fetch download link for {chapter_url} after {MAX_RETRIES} attempts.")
     return None
 
 async def extract_download_links(chapter_urls):
@@ -214,10 +224,11 @@ async def extract_download_links(chapter_urls):
         # Remove the "1.png" suffix from each download link
         download_links = [
             download_link[:-len("1.png")]
-            for download_link in results if download_link
+            for download_link in results #if download_link
         ]
 
     return download_links
+
 
 def download_page(response, page, base_download_link, download_path):
     """
@@ -252,6 +263,8 @@ def download_page(response, page, base_download_link, download_path):
 
     except requests.exceptions.RequestException as req_err:
         print(f"Error downloading {filename}: {req_err}")
+        with open("error_log.txt", "a") as log_file:
+            log_file.write(f"Error downloading {filename} from {download_link} : {req_err}\n")
 
 def download_chapter(item_info, pages_per_chapter, manga_name, task_info):
     """


### PR DESCRIPTION
When attempting to download a manga with more than approximately 50 chapters, some requests are likely to fail. This is, probably, due to a request limit imposed by the site through Cloudflare restrictions. To ensure all chapters are downloaded, multiple retries with a short delay are necessary.

Additionally, a log file (.txt) has been added to record cases where one or more images fail to download. This log includes the reason for failure, the manga title, chapter, and page number. This can help to debug missing images.

Several issues related to configuration and PDF generation have also been fixed.