### PR TITLE
add newline on logs

### DIFF
--- a/manga_downloader.py
+++ b/manga_downloader.py
@@ -201,7 +201,7 @@ def download_page(
         write_file(
             ERROR_LOG,
             mode="a",
-            content=f"Error downloading {filename} from {download_link}: {req_err}",
+            content=f"Error downloading {filename} from {download_link}: {req_err}\n",
         )
 
 


### PR DESCRIPTION
Added a newline character (\n) to log error messages. This ensures that each error entry is properly separated in the log file, improving readability.